### PR TITLE
Fix createOrUpdateResource manifest handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Retrieves events for a specific namespace or resource.
 Creates a new resource or updates an existing one from a YAML or JSON manifest.
 
 **Parameters:**
-- `manifest` (string, required): The YAML or JSON manifest of the resource.
+- `manifest` (string, required): The YAML or JSON manifest of the resource. The server accepts either format.
 - `namespace` (string, optional): The namespace in which to create/update the resource. If the manifest contains a namespace, this parameter can be used to override it. If not provided and the manifest doesn't specify one, "default" might be assumed or it might be an error depending on the resource type.
 
 **Example:**

--- a/handlers/k8s.go
+++ b/handlers/k8s.go
@@ -320,9 +320,8 @@ func CreateOrUpdateResource(client *k8s.Client) func(ctx context.Context, reques
 		}
 
 		namespace := getStringArg(args, "namespace", "")
-		resourceName := getStringArg(args, "resourceName", "")
 
-		resource, err := client.CreateOrUpdateResource(ctx, namespace, manifest, resourceName)
+		resource, err := client.CreateOrUpdateResource(ctx, namespace, manifest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create or update resource: %w", err)
 		}

--- a/tools/k8s.go
+++ b/tools/k8s.go
@@ -1,4 +1,3 @@
-
 // Package tools provides MCP tool handlers for interacting with Kubernetes.
 package tools
 
@@ -118,10 +117,9 @@ func GetEventsTool() mcp.Tool {
 // create or update resource of any type or kind
 func CreateOrUpdateResourceTool() mcp.Tool {
 	return mcp.NewTool(
-		"createResource",
-		mcp.WithDescription("Create a resource in the Kubernetes cluster"),
-		mcp.WithString("kind", mcp.Required(), mcp.Description("The type of resource to create")),
+		"createOrUpdateResource",
+		mcp.WithDescription("Create or update a resource in the Kubernetes cluster"),
 		mcp.WithString("namespace", mcp.Description("The namespace of the resource")),
-		mcp.WithString("manifest", mcp.Required(), mcp.Description("The manifest of the resource to create")),
+		mcp.WithString("manifest", mcp.Required(), mcp.Description("The manifest of the resource to create or update")),
 	)
 }


### PR DESCRIPTION
## Summary
- support YAML manifests in CreateOrUpdateResource
- remove unused kind and resourceName arguments
- rename tool to `createOrUpdateResource`
- document YAML/JSON manifest support

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685909983f8c8326ae8c78d9dd63ca8b