### PR TITLE
Allow object manifest for createOrUpdateResource

### DIFF
--- a/tools/k8s.go
+++ b/tools/k8s.go
@@ -120,6 +120,14 @@ func CreateOrUpdateResourceTool() mcp.Tool {
 		"createOrUpdateResource",
 		mcp.WithDescription("Create or update a resource in the Kubernetes cluster"),
 		mcp.WithString("namespace", mcp.Description("The namespace of the resource")),
-		mcp.WithString("manifest", mcp.Required(), mcp.Description("The manifest of the resource to create or update")),
+		// Accept the manifest as a generic object so callers don't have
+		// to JSON-escape the entire manifest string. This prevents
+		// encoding issues when agents send structured JSON.
+		mcp.WithObject(
+			"manifest",
+			mcp.Required(),
+			mcp.Description("The manifest of the resource to create or update"),
+			mcp.AdditionalProperties(true),
+		),
 	)
 }


### PR DESCRIPTION
## Summary
- allow passing a JSON object for the manifest when calling `createOrUpdateResource`
  - use `mcp.WithObject` instead of `mcp.WithString`
  - enable additional properties so any Kubernetes manifest is accepted

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68592334f49483269c17a8e49ca99c5a